### PR TITLE
Added support for google fonts 'com/css' extension

### DIFF
--- a/src/pixi-webfont-loader.ts
+++ b/src/pixi-webfont-loader.ts
@@ -13,7 +13,7 @@ export default class WebfontLoaderPlugin implements ILoaderPlugin
     }
     static use(resource: LoaderResource, next: (...params: any[]) => any): void
     {
-        if (resource.extension !== 'css')
+        if (!resource.extension.endsWith('css'))
         {
             next();
 


### PR DESCRIPTION
Thanks for this simple and nice pixi loader plugin!
I've got 'com/css' extension trying to load google font (https://fonts.googleapis.com/css?family=Open+Sans:400,600,700), so this fix make it works for me.

<img width="350" alt="Screen Shot 2020-12-16 at 9 38 08 PM" src="https://user-images.githubusercontent.com/9093671/102396549-a603d480-3fed-11eb-958d-0e6aa7117e5c.png">
